### PR TITLE
Log error instead of throwing

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -20,7 +20,8 @@ function cb (pkgName, foundPath) {
 function log () {
   var header = 'Some npm-link\'ed packaged were found:'
 
-  throw new Error(header + '\n' + list.join('\n') + '\n')
+  console.error(header + '\n' + list.join('\n') + '\n')
+  process.exitCode = 1
 }
 
 fs.stat(pathToNodeModules, function (err, stats) {

--- a/cmd.js
+++ b/cmd.js
@@ -20,7 +20,7 @@ function cb (pkgName, foundPath) {
 function log () {
   var header = 'Some npm-link\'ed packaged were found:'
 
-  console.error(header + '\n' + list.join('\n') + '\n')
+  console.log(header + '\n' + list.join('\n') + '\n')
   process.exitCode = 1
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -50,7 +50,7 @@ describe('simple project', function () {
     })
   })
 
-  it('should make cmd.js throw an error', function (done) {
+  it('should make cmd.js log an error', function (done) {
     exec(CMD + pathToProject, function (err, stdout, stderr) {
       if (err) assert.ok(err)
       assert.ok(/Some npm-link'ed packaged were found:/.test(stderr))

--- a/test/test.js
+++ b/test/test.js
@@ -50,10 +50,10 @@ describe('simple project', function () {
     })
   })
 
-  it('should make cmd.js log an error', function (done) {
+  it('should make cmd.js log', function (done) {
     exec(CMD + pathToProject, function (err, stdout, stderr) {
       if (err) assert.ok(err)
-      assert.ok(/Some npm-link'ed packaged were found:/.test(stderr))
+      assert.ok(/Some npm-link'ed packaged were found:/.test(stdout))
 
       done()
     })
@@ -107,11 +107,11 @@ describe('nested project', function () {
     setTimeout(done, DELAY)
   })
 
-  it('should make cmd.js throw an error', function (done) {
+  it('should make cmd.js log', function (done) {
     exec(CMD + pathToProject, function (err, stdout, stderr) {
       if (err) assert.ok(err)
 
-      assert.ok(/Some npm-link'ed packaged were found:/.test(stderr))
+      assert.ok(/Some npm-link'ed packaged were found:/.test(stdout))
 
       done()
     })

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,7 @@ describe('simple project', function () {
 
   function cb (pkgName, foundPath) {
     pkgList.push(pkgName)
-    foundPathList.push(foundPath)
+    foundPathList.push(path.normalize(foundPath))
   }
 
   before(function (done) {


### PR DESCRIPTION
Throwing an error when linked packages are found causes a stracktrace to be written to output, which makes it look like the script somehow failed. When first using the package, I first though something was wrong when I saw the stacktrace, until I realized that was expected behavior when linked packages were found

Using console.error() to write the message, and setting the exit code to 1, achieve the same result, but without the ugly and somewhat confusing stacktrace.

I also had to normalize the path for one of the 'simple project' tests to pass under Windows. 